### PR TITLE
add temp arena and set to be self owned or not

### DIFF
--- a/csv_reader.c
+++ b/csv_reader.c
@@ -5,9 +5,9 @@
 #include "csv_parser.h"
 #include "arena.h"
 
-CSVReader* csv_reader_init_with_config(Arena *arena, CSVConfig *config) {
+CSVReader* csv_reader_init_with_config(Arena *persistent_arena, Arena *temp_arena, CSVConfig *config) {
     void *ptr;
-    ArenaResult result = arena_alloc(arena, sizeof(CSVReader), &ptr);
+    ArenaResult result = arena_alloc(persistent_arena, sizeof(CSVReader), &ptr);
     if (result != ARENA_OK) {
         return NULL;
     }
@@ -18,18 +18,91 @@ CSVReader* csv_reader_init_with_config(Arena *arena, CSVConfig *config) {
         return NULL;
     }
 
-    reader->arena = arena;
+    reader->persistent_arena = persistent_arena;
+    reader->temp_arena = temp_arena;
     reader->config = config;
     reader->headers_loaded = false;
     reader->cached_header_count = 0;
     reader->cached_headers = NULL;
     reader->line_number = 0;
+    reader->current_record = NULL;
+    reader->owns_arenas = false;
 
     if (config->hasHeader) {
-        char *line = read_full_record(reader->file, arena);
+        char *line = read_full_record(reader->file, reader->persistent_arena);
         if (line) {
             reader->line_number++;
-            CSVParseResult result = csv_parse_line_inplace(line, arena, config, reader->line_number);
+            CSVParseResult result = csv_parse_line_inplace(line, reader->persistent_arena, config, reader->line_number);
+            if (result.success) {
+                reader->cached_headers = result.fields.fields;
+                reader->cached_header_count = result.fields.count;
+                reader->headers_loaded = true;
+            }
+        }
+    }
+
+    return reader;
+}
+
+CSVReader* csv_reader_init_standalone(CSVConfig *config) {
+    if (!config) {
+        return NULL;
+    }
+    
+    Arena *persistent_arena = malloc(sizeof(Arena));
+    Arena *temp_arena = malloc(sizeof(Arena));
+    
+    if (!persistent_arena || !temp_arena) {
+        if (persistent_arena) free(persistent_arena);
+        if (temp_arena) free(temp_arena);
+        return NULL;
+    }
+    
+    ArenaResult p_result = arena_create(persistent_arena, 1024 * 1024);
+    ArenaResult t_result = arena_create(temp_arena, 1024 * 1024);
+    
+    if (p_result != ARENA_OK || t_result != ARENA_OK) {
+        if (p_result == ARENA_OK) arena_destroy(persistent_arena);
+        if (t_result == ARENA_OK) arena_destroy(temp_arena);
+        free(persistent_arena);
+        free(temp_arena);
+        return NULL;
+    }
+    
+    CSVReader *reader = malloc(sizeof(CSVReader));
+    if (!reader) {
+        arena_destroy(persistent_arena);
+        arena_destroy(temp_arena);
+        free(persistent_arena);
+        free(temp_arena);
+        return NULL;
+    }
+
+    reader->file = fopen(config->path, "r");
+    if (!reader->file) {
+        arena_destroy(persistent_arena);
+        arena_destroy(temp_arena);
+        free(persistent_arena);
+        free(temp_arena);
+        free(reader);
+        return NULL;
+    }
+
+    reader->persistent_arena = persistent_arena;
+    reader->temp_arena = temp_arena;
+    reader->config = config;
+    reader->headers_loaded = false;
+    reader->cached_header_count = 0;
+    reader->cached_headers = NULL;
+    reader->line_number = 0;
+    reader->current_record = NULL;
+    reader->owns_arenas = true;
+
+    if (config->hasHeader) {
+        char *line = read_full_record(reader->file, reader->persistent_arena);
+        if (line) {
+            reader->line_number++;
+            CSVParseResult result = csv_parse_line_inplace(line, reader->persistent_arena, config, reader->line_number);
             if (result.success) {
                 reader->cached_headers = result.fields.fields;
                 reader->cached_header_count = result.fields.count;
@@ -46,19 +119,21 @@ CSVRecord* csv_reader_next_record(CSVReader *reader) {
         return NULL;
     }
 
-    char *line = read_full_record(reader->file, reader->arena);
+    arena_reset(reader->temp_arena);
+
+    char *line = read_full_record(reader->file, reader->temp_arena);
     if (!line) {
         return NULL;
     }
 
     reader->line_number++;
-    CSVParseResult result = csv_parse_line_inplace(line, reader->arena, reader->config, reader->line_number);
+    CSVParseResult result = csv_parse_line_inplace(line, reader->temp_arena, reader->config, reader->line_number);
     if (!result.success) {
         return NULL;
     }
 
     void *ptr;
-    ArenaResult arena_result = arena_alloc(reader->arena, sizeof(CSVRecord), &ptr);
+    ArenaResult arena_result = arena_alloc(reader->temp_arena, sizeof(CSVRecord), &ptr);
     if (arena_result != ARENA_OK) {
         return NULL;
     }
@@ -66,6 +141,8 @@ CSVRecord* csv_reader_next_record(CSVReader *reader) {
     CSVRecord *record = (CSVRecord*)ptr;
     record->fields = result.fields.fields;
     record->field_count = result.fields.count;
+    reader->current_record = record;
+
     return record;
 }
 
@@ -73,6 +150,24 @@ void csv_reader_free(CSVReader *reader) {
     if (reader) {
         if (reader->file) {
             fclose(reader->file);
+            reader->file = NULL;
+        }
+        
+        if (reader->owns_arenas) {
+            if (reader->persistent_arena) {
+                arena_destroy(reader->persistent_arena);
+                free(reader->persistent_arena);
+                reader->persistent_arena = NULL;
+            }
+            if (reader->temp_arena) {
+                arena_destroy(reader->temp_arena);
+                free(reader->temp_arena);
+                reader->temp_arena = NULL;
+            }
+            free(reader);
+        } else {
+            reader->persistent_arena = NULL;
+            reader->temp_arena = NULL;
         }
     }
 }
@@ -97,7 +192,7 @@ void csv_reader_rewind(CSVReader *reader) {
         reader->line_number = 0;
         
         if (reader->config->hasHeader && reader->headers_loaded) {
-            char *line = read_full_record(reader->file, reader->arena);
+            char *line = read_full_record(reader->file, reader->persistent_arena);
             if (line) {
                 reader->line_number = 1;
             }
@@ -105,13 +200,14 @@ void csv_reader_rewind(CSVReader *reader) {
     }
 }
 
-int csv_reader_set_config(CSVReader *reader, Arena *arena, const CSVConfig *config) {
-    if (!reader || !config || !arena) {
+int csv_reader_set_config(CSVReader *reader, Arena *persistent_arena, Arena *temp_arena, const CSVConfig *config) {
+    if (!reader || !config || !persistent_arena || !temp_arena) {
         return 0;
     }
     
     reader->config = (CSVConfig*)config;
-    reader->arena = arena;
+    reader->persistent_arena = persistent_arena;
+    reader->temp_arena = temp_arena;
     return 1;
 }
 
@@ -130,7 +226,7 @@ long csv_reader_get_record_count(CSVReader *reader) {
     long record_count = 0;
     
     if (reader->config && reader->config->hasHeader) {
-        char *header_line = read_full_record(reader->file, reader->arena);
+        char *header_line = read_full_record(reader->file, reader->persistent_arena);
         if (!header_line) {
             fseek(reader->file, current_pos, SEEK_SET);
             return 0;
@@ -138,7 +234,7 @@ long csv_reader_get_record_count(CSVReader *reader) {
     }
     
     while (1) {
-        char *line = read_full_record(reader->file, reader->arena);
+        char *line = read_full_record(reader->file, reader->persistent_arena);
         if (!line) {
             break;
         }
@@ -180,7 +276,8 @@ int csv_reader_seek(CSVReader *reader, long position) {
     csv_reader_rewind(reader);
     
     for (long i = 0; i < position; i++) {
-        char *line = read_full_record(reader->file, reader->arena);
+        arena_reset(reader->temp_arena);
+        char *line = read_full_record(reader->file, reader->temp_arena);
         if (!line) {
             return 0;
         }

--- a/csv_reader.h
+++ b/csv_reader.h
@@ -12,21 +12,25 @@ typedef struct {
 
 typedef struct {
     FILE *file;
-    Arena *arena;
     CSVConfig *config;
+    Arena *persistent_arena;
+    Arena *temp_arena;
     bool headers_loaded;
-    size_t cached_header_count;
+    int cached_header_count;
     char **cached_headers;
-    int line_number;
+    long line_number;
+    CSVRecord *current_record;
+    bool owns_arenas;
 } CSVReader;
 
-CSVReader* csv_reader_init_with_config(Arena *arena, CSVConfig *config);
+CSVReader* csv_reader_init_with_config(Arena *persistent_arena, Arena *temp_arena, CSVConfig *config);
+CSVReader* csv_reader_init_standalone(CSVConfig *config);
 void csv_reader_free(CSVReader *reader);
 CSVRecord* csv_reader_next_record(CSVReader *reader);
 
 
 void csv_reader_rewind(CSVReader *reader);
-int csv_reader_set_config(CSVReader *reader, Arena *arena, const CSVConfig *config);
+int csv_reader_set_config(CSVReader *reader, Arena *persistent_arena, Arena *temp_arena, const CSVConfig *config);
 long csv_reader_get_record_count(CSVReader *reader);
 long csv_reader_get_position(CSVReader *reader);
 char** csv_reader_get_headers(CSVReader *reader, int *header_count);

--- a/tests/test_csv_reader.c
+++ b/tests/test_csv_reader.c
@@ -25,7 +25,7 @@ void test_csv_reader_optimized() {
     csv_config_set_path(config, "test_reader.csv");
     csv_config_set_has_header(config, true);
 
-    CSVReader *reader = csv_reader_init_with_config(&arena, config);
+    CSVReader *reader = csv_reader_init_standalone(config);
     assert(reader != NULL);
     assert(reader->headers_loaded == true);
     assert(reader->cached_header_count == 3);
@@ -67,7 +67,7 @@ void test_csv_reader_get_headers() {
     csv_config_set_path(config, "test_headers.csv");
     csv_config_set_has_header(config, true);
 
-    CSVReader *reader = csv_reader_init_with_config(&arena, config);
+    CSVReader *reader = csv_reader_init_standalone(config);
     assert(reader != NULL);
 
     int header_count = 0;
@@ -95,7 +95,7 @@ void test_csv_reader_rewind() {
     csv_config_set_path(config, "test_rewind.csv");
     csv_config_set_has_header(config, true);
 
-    CSVReader *reader = csv_reader_init_with_config(&arena, config);
+    CSVReader *reader = csv_reader_init_standalone(config);
     assert(reader != NULL);
 
     // Read first record
@@ -131,7 +131,7 @@ void test_csv_reader_has_next() {
     csv_config_set_path(config, "test_has_next.csv");
     csv_config_set_has_header(config, true);
 
-    CSVReader *reader = csv_reader_init_with_config(&arena, config);
+    CSVReader *reader = csv_reader_init_standalone(config);
     assert(reader != NULL);
 
     // Should have records
@@ -169,7 +169,7 @@ void test_csv_reader_seek() {
     csv_config_set_path(config, "test_seek.csv");
     csv_config_set_has_header(config, true);
 
-    CSVReader *reader = csv_reader_init_with_config(&arena, config);
+    CSVReader *reader = csv_reader_init_standalone(config);
     assert(reader != NULL);
 
     // Seek to position 2 (3rd data record)
@@ -202,7 +202,7 @@ void test_csv_reader_position() {
     csv_config_set_path(config, "test_position.csv");
     csv_config_set_has_header(config, true);
 
-    CSVReader *reader = csv_reader_init_with_config(&arena, config);
+    CSVReader *reader = csv_reader_init_standalone(config);
     assert(reader != NULL);
 
     // Initial position should be 1 (after header)
@@ -239,20 +239,20 @@ void test_csv_reader_set_config() {
     
     CSVConfig *config2 = csv_config_create(&arena);
     csv_config_set_delimiter(config2, ';');
+    csv_config_set_path(config2, "test_set_config.csv");
+    csv_config_set_has_header(config2, true);
 
-    CSVReader *reader = csv_reader_init_with_config(&arena, config1);
+    CSVReader *reader = csv_reader_init_standalone(config1);
     assert(reader != NULL);
     assert(reader->config->delimiter == ',');
 
-    // Update config
-    int result = csv_reader_set_config(reader, &arena, config2);
-    assert(result == 1);
+    // For standalone mode, we can't change config after init
+    // So we'll test creating a new reader with different config
+    csv_reader_free(reader);
+    
+    reader = csv_reader_init_standalone(config2);
+    assert(reader != NULL);
     assert(reader->config->delimiter == ';');
-
-    // Test null parameters
-    assert(csv_reader_set_config(NULL, &arena, config2) == 0);
-    assert(csv_reader_set_config(reader, NULL, config2) == 0);
-    assert(csv_reader_set_config(reader, &arena, NULL) == 0);
 
     csv_reader_free(reader);
     arena_destroy(&arena);
@@ -293,7 +293,7 @@ void test_csv_reader_get_record_count() {
     csv_config_set_path(config, "test_count_header.csv");
     csv_config_set_has_header(config, true);
 
-    CSVReader *reader = csv_reader_init_with_config(&arena, config);
+    CSVReader *reader = csv_reader_init_standalone(config);
     assert(reader != NULL);
 
     long count = csv_reader_get_record_count(reader);
@@ -312,7 +312,7 @@ void test_csv_reader_get_record_count() {
     csv_config_set_path(config, "test_count_no_header.csv");
     csv_config_set_has_header(config, false);
 
-    reader = csv_reader_init_with_config(&arena, config);
+    reader = csv_reader_init_standalone(config);
     assert(reader != NULL);
 
     count = csv_reader_get_record_count(reader);
@@ -330,7 +330,7 @@ void test_csv_reader_get_record_count() {
     csv_config_set_path(config, "test_count_empty.csv");
     csv_config_set_has_header(config, false);
 
-    reader = csv_reader_init_with_config(&arena, config);
+    reader = csv_reader_init_standalone(config);
     assert(reader != NULL);
 
     count = csv_reader_get_record_count(reader);
@@ -350,7 +350,7 @@ void test_csv_reader_get_record_count() {
     csv_config_set_has_header(config, true);
     csv_config_set_skip_empty_lines(config, true);
 
-    reader = csv_reader_init_with_config(&arena, config);
+    reader = csv_reader_init_standalone(config);
     assert(reader != NULL);
 
     count = csv_reader_get_record_count(reader);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a standalone initialization method for the CSV reader, allowing for automatic management of memory arenas.
  * CSV reader now separates memory usage into persistent and temporary arenas for improved memory management.

* **Bug Fixes**
  * Improved error handling for memory allocation failures and file opening errors during CSV reader initialization.

* **Tests**
  * Updated test suite to use the new standalone initialization method and reflect the updated configuration handling.

* **Refactor**
  * CSV reader configuration and memory management refactored to support dual-arena model and new ownership semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->