### PR TITLE
Check for csv file on set path

### DIFF
--- a/csv_config.c
+++ b/csv_config.c
@@ -1,13 +1,21 @@
+#ifdef WIN32
+#include <io.h>
+#define F_OK 0
+#define access _access
+#else
+#include <unistd.h>
+#endif
+
 #include "csv_config.h"
 
 CSVConfig* csv_config_create(Arena *arena) {
     void *ptr;
     ArenaResult result = arena_alloc(arena, sizeof(CSVConfig), &ptr);
     if (result != ARENA_OK) return NULL;
-    
+
     CSVConfig *config = (CSVConfig*)ptr;
     memset(config, 0, sizeof(CSVConfig));
-    
+
     config->delimiter = ',';
     config->enclosure = '"';
     config->escape = '"';
@@ -19,7 +27,7 @@ CSVConfig* csv_config_create(Arena *arena) {
     config->trimFields = false;
     config->preserveQuotes = false;
     config->autoFlush = true;
-    
+
     return config;
 }
 
@@ -31,11 +39,11 @@ void csv_config_free(CSVConfig *config) {
 
 CSVConfig* csv_config_copy(Arena *arena, const CSVConfig *config) {
     if (!config) return NULL;
-    
+
     void *ptr;
     ArenaResult result = arena_alloc(arena, sizeof(CSVConfig), &ptr);
     if (result != ARENA_OK) return NULL;
-    
+
     CSVConfig *copy = (CSVConfig*)ptr;
     memcpy(copy, config, sizeof(CSVConfig));
     return copy;
@@ -110,6 +118,11 @@ void csv_config_set_escape(CSVConfig *config, char escape) {
 }
 
 void csv_config_set_path(CSVConfig *config, const char *path) {
+    if (access(path, F_OK) != 0) {
+        printf("Error: File %s does not exist!", path);
+        exit(1);
+    }
+
     if (config && path) {
         strncpy(config->path, path, MAX_PATH_LENGTH - 1);
         config->path[MAX_PATH_LENGTH - 1] = '\0';
@@ -154,4 +167,4 @@ void csv_config_set_preserve_quotes(CSVConfig *config, bool preserveQuotes) {
 
 void csv_config_set_auto_flush(CSVConfig *config, bool autoFlush) {
     if (config) config->autoFlush = autoFlush;
-} 
+}

--- a/csv_reader.c
+++ b/csv_reader.c
@@ -14,9 +14,6 @@ CSVReader* csv_reader_init_with_config(Arena *persistent_arena, Arena *temp_aren
 
     CSVReader *reader = (CSVReader*)ptr;
     reader->file = fopen(config->path, "r");
-    if (!reader->file) {
-        return NULL;
-    }
 
     reader->persistent_arena = persistent_arena;
     reader->temp_arena = temp_arena;
@@ -48,19 +45,19 @@ CSVReader* csv_reader_init_standalone(CSVConfig *config) {
     if (!config) {
         return NULL;
     }
-    
+
     Arena *persistent_arena = malloc(sizeof(Arena));
     Arena *temp_arena = malloc(sizeof(Arena));
-    
+
     if (!persistent_arena || !temp_arena) {
         if (persistent_arena) free(persistent_arena);
         if (temp_arena) free(temp_arena);
         return NULL;
     }
-    
+
     ArenaResult p_result = arena_create(persistent_arena, 1024 * 1024);
     ArenaResult t_result = arena_create(temp_arena, 1024 * 1024);
-    
+
     if (p_result != ARENA_OK || t_result != ARENA_OK) {
         if (p_result == ARENA_OK) arena_destroy(persistent_arena);
         if (t_result == ARENA_OK) arena_destroy(temp_arena);
@@ -68,7 +65,7 @@ CSVReader* csv_reader_init_standalone(CSVConfig *config) {
         free(temp_arena);
         return NULL;
     }
-    
+
     CSVReader *reader = malloc(sizeof(CSVReader));
     if (!reader) {
         arena_destroy(persistent_arena);
@@ -79,14 +76,6 @@ CSVReader* csv_reader_init_standalone(CSVConfig *config) {
     }
 
     reader->file = fopen(config->path, "r");
-    if (!reader->file) {
-        arena_destroy(persistent_arena);
-        arena_destroy(temp_arena);
-        free(persistent_arena);
-        free(temp_arena);
-        free(reader);
-        return NULL;
-    }
 
     reader->persistent_arena = persistent_arena;
     reader->temp_arena = temp_arena;
@@ -152,7 +141,7 @@ void csv_reader_free(CSVReader *reader) {
             fclose(reader->file);
             reader->file = NULL;
         }
-        
+
         if (reader->owns_arenas) {
             if (reader->persistent_arena) {
                 arena_destroy(reader->persistent_arena);
@@ -176,12 +165,12 @@ char** csv_reader_get_headers(CSVReader *reader, int *header_count) {
     if (!reader || !header_count) {
         return NULL;
     }
-    
+
     if (reader->headers_loaded) {
         *header_count = reader->cached_header_count;
         return reader->cached_headers;
     }
-    
+
     *header_count = 0;
     return NULL;
 }
@@ -190,7 +179,7 @@ void csv_reader_rewind(CSVReader *reader) {
     if (reader && reader->file) {
         rewind(reader->file);
         reader->line_number = 0;
-        
+
         if (reader->config->hasHeader && reader->headers_loaded) {
             char *line = read_full_record(reader->file, reader->persistent_arena);
             if (line) {
@@ -204,7 +193,7 @@ int csv_reader_set_config(CSVReader *reader, Arena *persistent_arena, Arena *tem
     if (!reader || !config || !persistent_arena || !temp_arena) {
         return 0;
     }
-    
+
     reader->config = (CSVConfig*)config;
     reader->persistent_arena = persistent_arena;
     reader->temp_arena = temp_arena;
@@ -215,16 +204,16 @@ long csv_reader_get_record_count(CSVReader *reader) {
     if (!reader || !reader->file) {
         return -1;
     }
-    
+
     long current_pos = ftell(reader->file);
     if (current_pos == -1) {
         return -1;
     }
-    
+
     rewind(reader->file);
-    
+
     long record_count = 0;
-    
+
     if (reader->config && reader->config->hasHeader) {
         char *header_line = read_full_record(reader->file, reader->persistent_arena);
         if (!header_line) {
@@ -232,13 +221,13 @@ long csv_reader_get_record_count(CSVReader *reader) {
             return 0;
         }
     }
-    
+
     while (1) {
         char *line = read_full_record(reader->file, reader->persistent_arena);
         if (!line) {
             break;
         }
-        
+
         if (reader->config && reader->config->skipEmptyLines) {
             bool is_empty = true;
             for (int i = 0; line[i] != '\0'; i++) {
@@ -251,12 +240,12 @@ long csv_reader_get_record_count(CSVReader *reader) {
                 continue;
             }
         }
-        
+
         record_count++;
     }
-    
+
     fseek(reader->file, current_pos, SEEK_SET);
-    
+
     return record_count;
 }
 
@@ -264,7 +253,7 @@ long csv_reader_get_position(CSVReader *reader) {
     if (!reader || !reader->file) {
         return -1;
     }
-    
+
     return reader->line_number;
 }
 
@@ -272,9 +261,9 @@ int csv_reader_seek(CSVReader *reader, long position) {
     if (!reader || !reader->file || position < 0) {
         return 0;
     }
-    
+
     csv_reader_rewind(reader);
-    
+
     for (long i = 0; i < position; i++) {
         arena_reset(reader->temp_arena);
         char *line = read_full_record(reader->file, reader->temp_arena);
@@ -283,7 +272,7 @@ int csv_reader_seek(CSVReader *reader, long position) {
         }
         reader->line_number++;
     }
-    
+
     return 1;
 }
 
@@ -291,14 +280,14 @@ int csv_reader_has_next(CSVReader *reader) {
     if (!reader || !reader->file) {
         return 0;
     }
-    
+
     long current_pos = ftell(reader->file);
     if (current_pos == -1) {
         return 0;
     }
-    
+
     int c = fgetc(reader->file);
     fseek(reader->file, current_pos, SEEK_SET);
-    
+
     return c != EOF;
-} 
+}


### PR DESCRIPTION
In this PR I made sure that the csv file exists from `csv_config_set_path()` before any further steps.

If the file does not exist, we show an error message and exit, we don't need to go any further, this check allows me to remove code that checks the file every time as we are sure now from the beginning that it exists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a runtime check to ensure the specified CSV file exists before proceeding, with an error message and immediate exit if the file is missing.

* **Bug Fixes**
  * Improved platform compatibility for file existence checks on both Windows and Unix-like systems.

* **Style**
  * Minor whitespace cleanup across files for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->