### PR TITLE
fix: use csv_config_copy to ensure config is properly duplicated in CSV Reader

### DIFF
--- a/csv_reader.c
+++ b/csv_reader.c
@@ -20,7 +20,7 @@ CSVReader* csv_reader_init_with_config(Arena *persistent_arena, Arena *temp_aren
 
     reader->persistent_arena = persistent_arena;
     reader->temp_arena = temp_arena;
-    reader->config = config;
+    reader->config = csv_config_copy(persistent_arena, config);
     reader->headers_loaded = false;
     reader->cached_header_count = 0;
     reader->cached_headers = NULL;
@@ -90,7 +90,7 @@ CSVReader* csv_reader_init_standalone(CSVConfig *config) {
 
     reader->persistent_arena = persistent_arena;
     reader->temp_arena = temp_arena;
-    reader->config = config;
+    reader->config = csv_config_copy(persistent_arena, config);
     reader->headers_loaded = false;
     reader->cached_header_count = 0;
     reader->cached_headers = NULL;


### PR DESCRIPTION
csv_reader now copies the config properly into persistent_arena using csv_config_copy instead of copying by pointer

This fixes #10 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CSV reader stability by ensuring its configuration is stored internally rather than relying on externally managed memory.
  * Reduced the risk of unexpected behavior when using CSV reader setup across different lifetimes or contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->